### PR TITLE
#8 Make (re-)build of bundle in upload task configurable

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -19,6 +19,7 @@ androidpublisher {
     shouldThrowIfNoReleaseNotes = true // <- optional, defaults true: defines whether an exception is thrown or not if no releaseNotes for the appVersionCode is found
     enableGenerateVersionCode = true // <- optional, defaults true: defines if the appVersionCode should be generated (read below)
     appVersionCodeKey = "yourCustomKey" // <- optional, defaults "appVersionCode": key under which the app's version code is stored in the gradle.properties file
+    createBundleIfNotExists = true // <- optional, defaults true: defines if the upload task should create a bundle in case it does not exist yet
 } 
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ch.hippmann"
-version = "0.1.2"
+version = "0.2.0"
 
 repositories {
     mavenLocal()

--- a/src/main/kotlin/ch/hippmann/androidpublisher/plugin/AndroidPublisherExtension.kt
+++ b/src/main/kotlin/ch/hippmann/androidpublisher/plugin/AndroidPublisherExtension.kt
@@ -10,4 +10,5 @@ open class AndroidPublisherExtension(objects: ObjectFactory) {
     val shouldThrowIfNoReleaseNotes = objects.property<Boolean>()
     val enableGenerateVersionCode = objects.property<Boolean>()
     val appVersionCodeKey = objects.property<String>()
+    val createBundleIfNotExists = objects.property<Boolean>()
 }

--- a/src/main/kotlin/ch/hippmann/androidpublisher/plugin/AndroidPublisherPlugin.kt
+++ b/src/main/kotlin/ch/hippmann/androidpublisher/plugin/AndroidPublisherPlugin.kt
@@ -51,13 +51,16 @@ class AndroidPublisherPlugin : Plugin<Project> {
                                 androidpublisher.credentialsJsonFile.get()
                             )
                         }
-                        }
+                    }
                 }
 
                 Track.values().map { it.toString() }.forEach { track ->
                     project.tasks.register("upload${applicationVariant.name.capitalize()}To${track.capitalize()}Track") {
                         group = TASK_GROUP
-                        dependsOn(project.tasks.getByName("bundle${applicationVariant.name.capitalize()}"))
+
+                        if (androidpublisher.createBundleIfNotExists.getOrElse(true)) {
+                            dependsOn(project.tasks.getByName("bundle${applicationVariant.name.capitalize()}"))
+                        }
 
                         doLast {
                             PlayStore.upload(


### PR DESCRIPTION
Previously the bundle might be recreated when triggering the upload task (e.g. because of different params for `bundle` and `upload`).