### PR TITLE
Custom track configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,5 @@ gradle-app.setting
 .jenv-version
 
 # End of https://www.toptal.com/developers/gitignore/api/jenv
+/play-store-credentials.json
+/local.properties

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -20,6 +20,15 @@ androidpublisher {
     enableGenerateVersionCode = true // <- optional, defaults true: defines if the appVersionCode should be generated (read below)
     appVersionCodeKey = "yourCustomKey" // <- optional, defaults "appVersionCode": key under which the app's version code is stored in the gradle.properties file
     createBundleIfNotExists = true // <- optional, defaults true: defines if the upload task should create a bundle in case it does not exist yet
+
+    customTracks { // <- optional: lets you define custom tracks to generate deployment tasks for
+     track("My custom track") // <- optional: defines a custom track named "My custom track" (same name as you gave it in the playstore) with the configuration applied above
+     track("My custom track with overridden options") { // <- optional: defines a custom track named "My custom track with overridden options" (same name as you gave it in the playstore) with the configuration applied above
+      releaseNotesFile = File("other/path/to/releaseNotes.csv") // optional: overrides the option "releaseNotesFile" for this track specifically
+      shouldThrowIfNoReleaseNotes = false // optional: overrides the option "shouldThrowIfNoReleaseNotes" for this track specifically
+      createBundleIfNotExists = false // optional: overrides the option "createBundleIfNotExists" for this track specifically
+     }
+    }
 } 
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Minimal gradle configuration:
 ```kotlin
 plugins {
     id("com.android.application")
-    id("ch.hippmann.androidpublisher") version "0.2.0"
+    id("ch.hippmann.androidpublisher") version "0.3.0"
 }
 
 androidpublisher {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ch.hippmann"
-version = "0.2.0"
+version = "0.3.0"
 
 repositories {
     mavenLocal()

--- a/src/main/kotlin/ch/hippmann/androidpublisher/plugin/AndroidPublisherExtension.kt
+++ b/src/main/kotlin/ch/hippmann/androidpublisher/plugin/AndroidPublisherExtension.kt
@@ -1,5 +1,6 @@
 package ch.hippmann.androidpublisher.plugin
 
+import ch.hippmann.androidpublisher.plugin.customtrack.CustomTrackConfiguration
 import org.gradle.api.model.ObjectFactory
 import org.gradle.kotlin.dsl.property
 import java.io.File
@@ -11,4 +12,9 @@ open class AndroidPublisherExtension(objects: ObjectFactory) {
     val enableGenerateVersionCode = objects.property<Boolean>()
     val appVersionCodeKey = objects.property<String>()
     val createBundleIfNotExists = objects.property<Boolean>()
+
+    val customTrackConfiguration = CustomTrackConfiguration()
+    fun customTracks(block: CustomTrackConfiguration.() -> Unit) {
+        block(customTrackConfiguration)
+    }
 }

--- a/src/main/kotlin/ch/hippmann/androidpublisher/plugin/customtrack/customTrackConfigurationDsl.kt
+++ b/src/main/kotlin/ch/hippmann/androidpublisher/plugin/customtrack/customTrackConfigurationDsl.kt
@@ -1,0 +1,26 @@
+package ch.hippmann.androidpublisher.plugin.customtrack
+
+import java.io.File
+
+@DslMarker
+annotation class CustomTrackDslMarker
+
+@CustomTrackDslMarker
+class CustomTrackConfiguration {
+    internal val customTracks = mutableSetOf<CustomTrack>()
+
+    fun track(trackId: String, configuration: CustomTrack.() -> Unit = {}) {
+        val track = CustomTrack(trackId)
+        configuration(track)
+        customTracks.add(track)
+    }
+}
+
+@CustomTrackDslMarker
+data class CustomTrack(
+    val trackId: String
+) {
+    var releaseNotesFile: File? = null
+    var shouldThrowIfNoReleaseNotes: Boolean? = null
+    var createBundleIfNotExists: Boolean? = null
+}

--- a/src/main/kotlin/ch/hippmann/androidpublisher/plugin/customtrack/customTrackConfigurationDsl.kt
+++ b/src/main/kotlin/ch/hippmann/androidpublisher/plugin/customtrack/customTrackConfigurationDsl.kt
@@ -18,9 +18,8 @@ class CustomTrackConfiguration {
 
 @CustomTrackDslMarker
 data class CustomTrack(
-    val trackId: String
-) {
-    var releaseNotesFile: File? = null
-    var shouldThrowIfNoReleaseNotes: Boolean? = null
+    val trackId: String,
+    var releaseNotesFile: File? = null,
+    var shouldThrowIfNoReleaseNotes: Boolean? = null,
     var createBundleIfNotExists: Boolean? = null
-}
+)


### PR DESCRIPTION
This implements support for custom play store tracks

When configured, additional deployment tasks are registered for the specified custom tracks.
For each defined custom track, the following options from the general plugin configuration can be overridden:
- `releaseNotesFile`
- `shouldThrowIfNoReleaseNotes`
- `createBundleIfNotExists`

If not overridden, it defaults to the configuration defined for the whole plugin inside the `androidpublisher` block.