### PR TITLE
Update dependencies, replace embedded kotlin and replace authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Minimal gradle configuration:
 ```kotlin
 plugins {
     id("com.android.application")
-    id("ch.hippmann.androidpublisher") version "0.3.0"
+    id("ch.hippmann.androidpublisher") version "0.3.1"
 }
 
 androidpublisher {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,39 +1,33 @@
 plugins {
-    `kotlin-dsl`
+    // https://kotlinlang.org/docs/releases.html
+    kotlin("jvm") version "1.8.0"
+    `java-gradle-plugin`
     `maven-publish`
-    id("com.gradle.plugin-publish") version "0.11.0"
+    // https://plugins.gradle.org/plugin/com.gradle.plugin-publish
+    id("com.gradle.plugin-publish") version "1.1.0"
 }
 
 group = "ch.hippmann"
-version = "0.3.0"
+version = "0.3.1"
 
 repositories {
     mavenLocal()
-    jcenter()
+    mavenCentral()
     google()
 }
 
 gradlePlugin {
+    website.set("https://github.com/chippmann/androidpublisher")
+    vcsUrl.set("https://github.com/chippmann/androidpublisher.git")
+
     plugins {
         create("androidpublisher") {
             id = "ch.hippmann.androidpublisher"
             displayName = "Publish apps to the Google Play Store"
             description = "Gradle plugin for publishing apps to the Google Play Store"
+            tags.set(listOf("kotlin", "android", "playstore"))
             implementationClass = "ch.hippmann.androidpublisher.plugin.AndroidPublisherPlugin"
         }
-    }
-    isAutomatedPublishing = false
-}
-
-pluginBundle {
-    website = "https://github.com/chippmann/androidpublisher"
-    vcsUrl = "https://github.com/chippmann/androidpublisher.git"
-    tags = listOf("kotlin", "android", "playstore")
-
-    mavenCoordinates {
-        groupId = "${project.group}"
-        artifactId = "androidpublisher-gradle-plugin"
-        version = "${project.version}"
     }
 }
 
@@ -41,19 +35,24 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation(kotlin("gradle-plugin"))
     implementation(kotlin("gradle-plugin-api"))
-    compileOnly("com.android.tools.build:gradle:3.6.2")
-    implementation("com.google.apis:google-api-services-androidpublisher:v3-rev20200331-1.30.9")
-    implementation("com.github.doyaaaaaken:kotlin-csv-jvm:0.7.3")
+    // https://developer.android.com/studio/releases/gradle-plugin
+    compileOnly("com.android.tools.build:gradle:7.3.0")
+
+    // https://search.maven.org/artifact/com.google.apis/google-api-services-androidpublisher
+    implementation("com.google.apis:google-api-services-androidpublisher:v3-rev20221108-2.0.0")
+
+    // Required to read the credentials from the credentials json file. Library suggested in the corresponding deprecation notes of google-api-services-androidpublisher
+    // https://github.com/googleapis/google-auth-library-java/releases
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.14.0")
+
+    // TODO: remove once a new version of com.google.apis:google-api-services-androidpublisher is out. This is here to override the requested version of the dependency as the requested version (1.11) has a security vulnerability: Cxeb68d52e-5509 (https://devhub.checkmarx.com/cve-details/Cxeb68d52e-5509/) 3.7 Exposure of Sensitive Information to an Unauthorized Actor vulnerability pending CVSS allocation
+    implementation("commons-codec:commons-codec:1.15")
+
+    // https://github.com/doyaaaaaken/kotlin-csv/releases
+    implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.7.0")
 }
 
 tasks {
-    val sourceJar by creating(Jar::class) {
-        archiveBaseName.set(project.name)
-        archiveVersion.set(project.version.toString())
-        archiveClassifier.set("sources")
-        from(sourceSets["main"].allSource)
-    }
-
     build {
         finalizedBy(publishToMavenLocal)
     }
@@ -62,6 +61,7 @@ tasks {
 publishing {
     publications {
         // this is only used for publishing locally.
+        @Suppress("UNUSED_VARIABLE")
         val androidpublisherPlugin by creating(MavenPublication::class) {
             pom {
                 groupId = "${project.group}"
@@ -69,7 +69,6 @@ publishing {
                 version = "${project.version}"
             }
             from(components.getByName("java"))
-            artifact(tasks.getByName("sourceJar"))
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/ch/hippmann/androidpublisher/plugin/AndroidPublisherExtension.kt
+++ b/src/main/kotlin/ch/hippmann/androidpublisher/plugin/AndroidPublisherExtension.kt
@@ -2,16 +2,16 @@ package ch.hippmann.androidpublisher.plugin
 
 import ch.hippmann.androidpublisher.plugin.customtrack.CustomTrackConfiguration
 import org.gradle.api.model.ObjectFactory
-import org.gradle.kotlin.dsl.property
+import org.gradle.api.provider.Property
 import java.io.File
 
 open class AndroidPublisherExtension(objects: ObjectFactory) {
-    val credentialsJsonFile = objects.property<File>()
-    val releaseNotesFile = objects.property<File>()
-    val shouldThrowIfNoReleaseNotes = objects.property<Boolean>()
-    val enableGenerateVersionCode = objects.property<Boolean>()
-    val appVersionCodeKey = objects.property<String>()
-    val createBundleIfNotExists = objects.property<Boolean>()
+    val credentialsJsonFile: Property<File> = objects.property(File::class.java)
+    val releaseNotesFile: Property<File> = objects.property(File::class.java)
+    val shouldThrowIfNoReleaseNotes: Property<Boolean> = objects.property(Boolean::class.java)
+    val enableGenerateVersionCode: Property<Boolean> = objects.property(Boolean::class.java)
+    val appVersionCodeKey: Property<String> = objects.property(String::class.java)
+    val createBundleIfNotExists: Property<Boolean> = objects.property(Boolean::class.java)
 
     val customTrackConfiguration = CustomTrackConfiguration()
     fun customTracks(block: CustomTrackConfiguration.() -> Unit) {

--- a/src/main/kotlin/ch/hippmann/androidpublisher/publisher/Track.kt
+++ b/src/main/kotlin/ch/hippmann/androidpublisher/publisher/Track.kt
@@ -7,6 +7,6 @@ enum class Track {
     PRODUCTION;
 
     override fun toString(): String {
-        return this.name.toLowerCase()
+        return this.name.lowercase()
     }
 }


### PR DESCRIPTION
# Update dependencies
One thing to note: `v3-rev20221108-2.0.0` of `google-api-services-androidpublisher` uses version `1.11` of `commons-codec:commons-codec` which has a security vulnerability: [Cxeb68d52e-5509](https://devhub.checkmarx.com/cve-details/Cxeb68d52e-5509/). We thus manually override the used version with `1.15` for now.

# Embedded kotlin replacement (`kotlin-dsl`):
One major downside of using the embedded kotlin version of gradle (by using the `kotlin-dsl` notation in the plugins block) is that one is limited to the often times pretty old kotlin version that is shipped with gradle. As the kotlin version should be mostly independent of the gradle version used, the `kotlin-dsl` notation is replaced by the regular `kotlin("jvm")` notation. This also required slight rework of the plugin configuration as some dsl functions are no longer available in the plugin class.

# Replace authentication
The `GoogleCredential` from the `google-api-services-androidpublisher` library was deprecated a while ago. This now replaces it with `google-auth-library-oauth2-http` as suggested by the deprecation note.